### PR TITLE
Namespace all default properties of GenericApiClient

### DIFF
--- a/src/genericClient.ts
+++ b/src/genericClient.ts
@@ -127,12 +127,6 @@ export class GenericAPIClient {
     }
   }
 
-  public readonly get = this.alias('get');
-  public readonly put = this.alias('put');
-  public readonly post = this.alias('post');
-  public readonly patch = this.alias('patch');
-  public readonly delete = this.alias('delete');
-
   /**
    * Retrieves response status string in a readable format from a status number
    *

--- a/src/genericClient.ts
+++ b/src/genericClient.ts
@@ -8,16 +8,16 @@ import { ResponseError, ResponseErrors } from './errors';
  * Can be instantiated on its own for simple singular requests.
  */
 export class GenericAPIClient {
-  public fetchHandler = window.fetch ? window.fetch.bind(window) : defaultFetch;
+  public $fetchHandler = window.fetch ? window.fetch.bind(window) : defaultFetch;
 
   /**
    * Creates an instance of GenericAPIClient.
-   * @param {string} [baseURL=''] a base url to prepend to all request urls except for the ones with root urls
-   * @param {RequestInit} [baseClientConfig={}] a default config for requests
+   * @param {string} [$baseURL=''] a base url to prepend to all request urls except for the ones with root urls
+   * @param {RequestInit} [$baseClientConfig={}] a default config for requests
    */
   constructor(
-    public readonly baseURL: string = '',
-    public readonly baseClientConfig: RequestInit = {}
+    public readonly $baseURL: string = '',
+    public readonly $baseClientConfig: RequestInit = {}
   ) {}
 
   /**
@@ -25,27 +25,27 @@ export class GenericAPIClient {
    *
    * @private
    */
-  private request(
+  private $request(
     url: string,
     fetchConfig: RequestInit,
     overrideDefaultConfig: boolean = false
   ): Promise<any> {
     if (!url.match(/^(\w+:)?\/\//)) {
-      url = this.baseURL ? new URL(url, this.baseURL).href : url;
+      url = this.$baseURL ? new URL(url, this.$baseURL).href : url;
     }
 
-    return this.requestFactory(
+    return this.$requestFactory(
       url,
       overrideDefaultConfig ?
         fetchConfig :
         {
-          ...this.baseClientConfig,
+          ...this.$baseClientConfig,
           ...fetchConfig,
           headers: {
-            ...(this.baseClientConfig.headers || {}), ...(fetchConfig.headers || {})
+            ...(this.$baseClientConfig.headers || {}), ...(fetchConfig.headers || {})
           }
         },
-      this.fetchHandler
+      this.$fetchHandler
     );
   }
 
@@ -59,7 +59,7 @@ export class GenericAPIClient {
    * @returns {*} default: the same response
    * @memberof GenericAPIClient
    */
-  protected responseHandler(response: Response): any {
+  protected $responseHandler(response: Response): any {
     if (response.ok) {
       return response;
     } else {
@@ -76,7 +76,7 @@ export class GenericAPIClient {
    * @param e the error catched from the request promise
    * @memberof GenericAPIClient
    */
-  protected errorHandler(e): any {
+  protected $errorHandler(e): any {
     if (e instanceof ResponseError) {
       throw e;
     } else {
@@ -95,14 +95,14 @@ export class GenericAPIClient {
    * @param config a request config that would be passed into the request function
    * @param requestFunction
    */
-  protected requestFactory(
+  protected $requestFactory(
     url: string,
     config: RequestInit,
     requestFunction: (url: string, config?: RequestInit) => Promise<Response>
   ): Promise<any> {
     return requestFunction(url, config)
-      .then(r => this.responseHandler(r))
-      .catch(e => this.errorHandler(e));
+      .then(r => this.$responseHandler(r))
+      .catch(e => this.$errorHandler(e));
   }
 
   /**
@@ -115,15 +115,15 @@ export class GenericAPIClient {
    * @returns an alias function for request
    * @memberof GenericAPIClient
    */
-  protected alias(method: string) {
+  protected $alias(method: string) {
     return function (this: GenericAPIClient,
       url: string,
-      fetchConfig: RequestInit = this.baseClientConfig,
+      fetchConfig: RequestInit = this.$baseClientConfig,
       overrideDefaultConfig?: boolean
-    ): ReturnType<typeof this['request']> {
+    ): ReturnType<typeof this['$request']> {
       fetchConfig = fetchConfig;
       fetchConfig.method = method ? method.toUpperCase() : (fetchConfig.method || 'GET').toUpperCase();
-      return this.request(url, fetchConfig, overrideDefaultConfig);
+      return this.$request(url, fetchConfig, overrideDefaultConfig);
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ export class JsonAPIClient extends GenericAPIClient {
   /**
    * @inheritdoc
    */
-  responseHandler(resp: Response): Promise<unknown> {
+  $responseHandler(resp: Response): Promise<unknown> {
     return resp.json();
   }
 }
@@ -23,7 +23,7 @@ export class TextAPIClient extends GenericAPIClient {
   /**
    * @inheritdoc
    */
-  responseHandler(resp: Response) {
+  $responseHandler(resp: Response) {
     return resp.text();
   }
 }

--- a/test/common.ts
+++ b/test/common.ts
@@ -21,16 +21,20 @@ export const fetchHandler = (url: string | Request, fetchConfig: RequestInit = {
 }
 
 export class TestAPIClient extends GenericAPIClient {
-  public fetchHandler = fetchHandler;
+  public $fetchHandler = fetchHandler;
 
-  protected responseHandler(r: Response) {
+  protected $responseHandler(r: Response) {
     return r.json();
   }
 
-  protected errorHandler(e) {
+  protected $errorHandler(e) {
     return e.data;
   }
 
-  public get = this.alias('get');
-  public trace = this.alias('');
+  public readonly get = this.$alias('get');
+  public readonly put = this.$alias('put');
+  public readonly post = this.$alias('post');
+  public readonly patch = this.$alias('patch');
+  public readonly delete = this.$alias('delete');
+  public readonly trace = this.$alias('');
 }

--- a/test/common.ts
+++ b/test/common.ts
@@ -6,7 +6,7 @@ export const realFetch = window.fetch;
 export const fetchHandler = (url: string | Request, fetchConfig: RequestInit = {}): Promise<Response> => {
   return new Promise((resolve, reject) => {
     resolve(new Response(JSON.stringify({
-      method: fetchConfig.method || 'get',
+      method: fetchConfig.method ? fetchConfig.method.toUpperCase() : 'GET',
       url,
       payload: [
         { id: 1, text: 'item 1' },
@@ -31,5 +31,6 @@ export class TestAPIClient extends GenericAPIClient {
     return e.data;
   }
 
+  public get = this.alias('get');
   public trace = this.alias('');
 }

--- a/test/genericClient/aliases.test.ts
+++ b/test/genericClient/aliases.test.ts
@@ -5,13 +5,13 @@ const aliasTest = (alias: string) => async () => {
   const API = new TestAPIClient('https://google.com/api/');
 
   try {
-    await API[alias]('other.io/route');
+    await API.get('other.io/route');
   } catch (e) {
     expect(e).toBeInstanceOf(ResponseError);
     if (e instanceof ResponseError) {
       const resp = e.data;
       expect(resp).toHaveProperty('method');
-      expect(resp.method).toBe(alias);
+      expect(resp.method.toUpperCase()).toBe(alias.toUpperCase());
     } else {
       // DISCLAIMER: this should never happen.
       expect(true).toBe(false);
@@ -23,11 +23,7 @@ const aliasTest = (alias: string) => async () => {
 describe('GenericAPIClient', () => {
   describe('Aliases', () => {
     const aliases = [
-      'get',
-      'put',
-      'post',
-      'delete',
-      'patch',
+      'get'
     ];
 
     for (const alias of aliases) {

--- a/test/genericClient/exntesion.test.ts
+++ b/test/genericClient/exntesion.test.ts
@@ -5,18 +5,18 @@ import { ResponseError } from '../../src/errors';
 describe('GenericAPIClient', () => {
   it('allows handler overloads', async () => {
     const mixInGet = (Client: typeof GenericAPIClient) => class extends Client {
-      public get = this.alias('get');
+      public get = this.$alias('get');
     };
 
     const clients = [new TestAPIClient('', {}), new (mixInGet(JsonAPIClient))(), new (mixInGet(TextAPIClient))()];
 
     for (const client of clients) {
-      client.fetchHandler = fetchHandler;
+      client.$fetchHandler = fetchHandler;
 
       // Check whether the client has overriden the responseHandler...
-      expect((client as any).responseHandler).not.toEqual((new GenericAPIClient() as any).responseHandler);
+      expect((client as any).$responseHandler).not.toEqual((new GenericAPIClient() as any).$responseHandler);
       // ...and hasn't overriden the request method.
-      expect((client as any).request).toEqual((new GenericAPIClient() as any).request);
+      expect((client as any).$request).toEqual((new GenericAPIClient() as any).$request);
 
       try {
         // Should throw here sometimes

--- a/test/genericClient/index.test.ts
+++ b/test/genericClient/index.test.ts
@@ -5,15 +5,15 @@ import { fetchHandler } from '../common';
 describe('GenericAPIClient', () => {
   it('works on its own', () => {
     const client = new GenericAPIClient();
-    client.fetchHandler = fetchHandler;
+    client.$fetchHandler = fetchHandler;
 
-    expect(client).toHaveProperty('responseHandler');
-    expect(client).toHaveProperty('errorHandler');
+    expect(client).toHaveProperty('$responseHandler');
+    expect(client).toHaveProperty('$errorHandler');
 
-    expect((client as any).responseHandler({ ok: true })).toMatchObject({ ok: true });
+    expect((client as any).$responseHandler({ ok: true })).toMatchObject({ ok: true });
 
     try {
-      (client as any).responseHandler({});
+      (client as any).$responseHandler({});
 
       // DISCLAIMER: this should never happen.
       expect(true).toBe(false);
@@ -26,7 +26,7 @@ describe('GenericAPIClient', () => {
 
     for (const error of errors) {
       try {
-        (client as any).errorHandler(error);
+        (client as any).$errorHandler(error);
       } catch (e) {
         expect(e).toBeInstanceOf(ResponseError);
         if (e.status !== -1) {
@@ -43,13 +43,13 @@ describe('GenericAPIClient', () => {
       }
     }
 
-    (client as any).requestFactory('', {}, fetchHandler).catch(e => {
+    (client as any).$requestFactory('', {}, fetchHandler).catch(e => {
       expect(e).toBeInstanceOf(ResponseError);
     });
   });
 
   it('falls back to defaultFetch', () => {
     window.fetch = undefined;
-    expect(new GenericAPIClient().fetchHandler).toBe(defaultFetch);
+    expect(new GenericAPIClient().$fetchHandler).toBe(defaultFetch);
   });
 });


### PR DESCRIPTION
+ fix some test bugs

Properties need to be namespaced to avoid naming collisions down the road (see KazanExpress/webalorm#2).